### PR TITLE
Fork PR by Tom Avital: Added OpenShift Support

### DIFF
--- a/helm/fabric/templates/deployment.yaml
+++ b/helm/fabric/templates/deployment.yaml
@@ -8,6 +8,8 @@
 {{ $serviceAccount := default dict .Values.serviceAccount }}
 {{ $serviceAccountName := default (include "fabric.namespace" .) $serviceAccount.name }}
 {{ $storage := default dict .Values.storage }}
+{{ $pvc := default dict $storage.pvc }}
+{{ $emptyDir := default dict $storage.emptyDir }}
 {{ $container := default dict .Values.container }}
 {{ $container_labels := default (list) $container.labels }}
 {{ $resource_annotations := default (list) $container.annotations }}
@@ -23,6 +25,7 @@
 {{ $livenessProbe := default dict $container.livenessProbe }}
 {{ $readinessProbe := default dict $container.readinessProbe }}
 {{ $startupProbe := default dict $container.startupProbe }}
+{{ $openshift := .Values.openshift | default false }}
 
 {{ if eq $type "Deployment" }}
 apiVersion: apps/v1
@@ -117,6 +120,8 @@ spec:
                 memory: {{ $requests.memory | default "4Gi" }}
                 cpu: {{ $requests.cpu | default "1" }}
             env:
+            - name: HOME
+              value: /opt/apps/fabric
             - name: NAMESPACE
               value: {{ include "fabric.namespace" . }}
             # common secrets
@@ -179,6 +184,8 @@ spec:
                 memory: {{ $requests.memory | default "4Gi" }}
                 cpu: {{ $requests.cpu | default "1" }}
             env:
+            - name: HOME
+              value: /opt/apps/fabric
             - name: NAMESPACE
               value: {{ include "fabric.namespace" . }}
             {{- range $secret := $secretsList }}
@@ -238,8 +245,13 @@ spec:
           {{- end }}
           volumes:
           - name: fabric-storage
+            {{- if ne (toString $pvc.enabled) "false" }}
             persistentVolumeClaim:
               claimName: fabric-claim
+            {{- else }}
+            emptyDir:
+              sizeLimit: {{ $emptyDir.sizeLimit | default "10Gi" }}
+            {{- end }}
           - name: fabric-storage-private
             emptyDir:
               sizeLimit: 10Gi

--- a/helm/fabric/templates/ingress.yaml
+++ b/helm/fabric/templates/ingress.yaml
@@ -5,6 +5,7 @@
 {{ $annotations := default (list) .Values.annotations }}
 {{ $ingress := default dict .Values.ingress }}
 {{ $cert_manager := default dict $ingress.cert_manager }}
+{{ $openshift := .Values.openshift | default false }}
 {{ $path := "" }}
 {{ if kindIs "string" $ingress.path }}
   {{- $path = $ingress.path }}
@@ -19,7 +20,7 @@
   {{- $host = printf "%s.%s" $subdomain $ingress.host }}
 {{ end }}
 
-{{ if $ingress.enabled | default true }}
+{{ if and (not $openshift) ($ingress.enabled | default true) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/helm/fabric/templates/ingress_np.yaml
+++ b/helm/fabric/templates/ingress_np.yaml
@@ -6,6 +6,7 @@
 {{ $networkPolicy := default dict .Values.networkPolicy }}
 {{ $ingress := default dict $networkPolicy.ingress }}
 {{ $resource_annotations := default (list) $networkPolicy.annotations }}
+{{ $openshift := .Values.openshift | default false }}
 
 {{ if $ingress.enabled | default false }}
 apiVersion: networking.k8s.io/v1
@@ -90,4 +91,13 @@ spec:
         - podSelector:
             matchLabels:
               job-name: fabric-deployer
+    {{- if $openshift }}
+    - ports:
+        - protocol: TCP
+          port: 3213
+      from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+    {{- end }}
 {{ end }}

--- a/helm/fabric/templates/pvc.yaml
+++ b/helm/fabric/templates/pvc.yaml
@@ -8,7 +8,7 @@
 {{ $resource_annotations := default (list) $storage.annotations }}
 {{ $allocated_amount := default $storage.allocated_amount $storage.alocated_amount }} {{- /* for backward compatibility, fix spelling error */ -}}
 
-{{ if $pvc.enabled | default true }}
+{{ if ne (toString $pvc.enabled) "false" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/fabric/templates/route.yaml
+++ b/helm/fabric/templates/route.yaml
@@ -1,0 +1,93 @@
+{{ $namespace := default dict .Values.namespace }}
+{{ $global := default dict .Values.global }}
+{{ $global_labels := default (list) $global.labels }}
+{{ $labels := default (list) .Values.labels }}
+{{ $global_annotations := default (list) $global.annotations }}
+{{ $annotations := default (list) .Values.annotations }}
+{{ $openshift := .Values.openshift | default false }}
+{{ $route := default dict .Values.route }}
+{{ $ingress := default dict .Values.ingress }}
+{{ $tls := default dict $route.tls }}
+{{ $service := default dict .Values.service }}
+
+{{/* Compute host: use route.host if set, otherwise fall back to ingress host/subdomain logic */}}
+{{ $host := $route.host }}
+{{- if not $host }}
+  {{- $host = $ingress.host | default "" }}
+  {{- if and (kindIs "string" $ingress.subdomain) $ingress.subdomain }}
+    {{- $host = printf "%s.%s" $ingress.subdomain $host }}
+  {{- else if and (kindIs "bool" $ingress.subdomain) $ingress.subdomain }}
+    {{- $subdomain := default $.Release.Name $namespace.name }}
+    {{- $host = printf "%s.%s" $subdomain $host }}
+  {{- end }}
+{{- end }}
+
+{{/* Compute path: use route.path if set, otherwise fall back to ingress path logic */}}
+{{ $path := $route.path }}
+{{- if not $path }}
+  {{- if kindIs "string" $ingress.path }}
+    {{- $path = printf "/%s" $ingress.path }}
+  {{- else if and (kindIs "bool" $ingress.path) $ingress.path }}
+    {{- $path = printf "/%s" (default $.Release.Name $namespace.name) }}
+  {{- end }}
+{{- end }}
+
+{{- if and $openshift ($route.enabled | default true) }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: fabric-route
+  namespace: {{ default .Release.Name $namespace.name }}
+  labels:
+    app: fabric
+    {{- range $label := $labels }}
+    {{ $label.name }}: {{ $label.value }}
+    {{- end }}
+    {{- range $label := $global_labels }}
+    {{ $label.name }}: {{ $label.value }}
+    {{- end }}
+  {{- if or $global_annotations $annotations }}
+  annotations:
+    {{- range $annotation := $global_annotations }}
+    {{ $annotation.key }}: {{ $annotation.value | quote }}
+    {{- end }}
+    {{- range $annotation := $annotations }}
+    {{ $annotation.key }}: {{ $annotation.value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if $host }}
+  host: {{ $host }}
+  {{- end }}
+  {{- if $path }}
+  path: {{ $path }}
+  {{- end }}
+  to:
+    kind: Service
+    name: fabric-service
+    weight: 100
+  port:
+    targetPort: fabric-port
+  {{- if $tls.enabled | default true }}
+  tls:
+    termination: {{ $tls.termination | default "edge" }}
+    insecureEdgeTerminationPolicy: {{ $tls.insecureEdgeTerminationPolicy | default "Redirect" }}
+    {{- if $tls.certificate }}
+    certificate: |
+{{ $tls.certificate | indent 6 }}
+    {{- end }}
+    {{- if $tls.key }}
+    key: |
+{{ $tls.key | indent 6 }}
+    {{- end }}
+    {{- if $tls.caCertificate }}
+    caCertificate: |
+{{ $tls.caCertificate | indent 6 }}
+    {{- end }}
+    {{- if $tls.destinationCACertificate }}
+    destinationCACertificate: |
+{{ $tls.destinationCACertificate | indent 6 }}
+    {{- end }}
+  {{- end }}
+  wildcardPolicy: {{ $route.wildcardPolicy | default "None" }}
+{{- end }}

--- a/helm/fabric/templates/scc_rolebinding.yaml
+++ b/helm/fabric/templates/scc_rolebinding.yaml
@@ -1,0 +1,21 @@
+{{ $openshift := .Values.openshift | default false }}
+{{ $serviceAccount := default dict .Values.serviceAccount }}
+{{ $serviceAccountName := default (include "fabric.namespace" .) $serviceAccount.name }}
+
+{{- if $openshift }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fabric-anyuid-scc
+  namespace: {{ include "fabric.namespace" . }}
+  labels:
+    app: fabric
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+  - kind: ServiceAccount
+    name: {{ if ne $serviceAccount.name "" }}{{ $serviceAccountName }}{{ else }}{{ $serviceAccountName }}-sa{{ end }}
+    namespace: {{ include "fabric.namespace" . }}
+{{- end }}

--- a/helm/fabric/templates/statefulsets.yaml
+++ b/helm/fabric/templates/statefulsets.yaml
@@ -8,6 +8,7 @@
 {{ $serviceAccount := default dict .Values.serviceAccount }}
 {{ $serviceAccountName := default (include "fabric.namespace" .) $serviceAccount.name }}
 {{ $storage := default dict .Values.storage }}
+{{ $pvc := default dict $storage.pvc }}
 {{ $allocated_amount := default $storage.allocated_amount $storage.alocated_amount }} {{- /* for backward compatibility, fix spelling error */ -}}
 {{ $container := default dict .Values.container }}
 {{ $resource_annotations := default (list) $container.annotations }}
@@ -23,6 +24,7 @@
 {{ $livenessProbe := default dict $container.livenessProbe }}
 {{ $readinessProbe := default dict $container.readinessProbe }}
 {{ $startupProbe := default dict $container.startupProbe }}
+{{ $openshift := .Values.openshift | default false }}
 
 {{ if eq $type "StatefulSet" }}
 apiVersion: apps/v1
@@ -59,6 +61,7 @@ spec:
     selector:
       matchLabels:
         app: fabric
+    {{- if ne (toString $pvc.enabled) "false" }}
     volumeClaimTemplates:
     - metadata:
         name: fabric-storage-private
@@ -70,6 +73,7 @@ spec:
         resources:
           requests:
             storage: {{ default "10Gi" $allocated_amount }}
+    {{- end }}
     template:
         metadata:
           labels: *id001
@@ -237,7 +241,7 @@ spec:
               mountPath: {{ $mountSecretB64enc.mountPath }}
             {{- end }}
           terminationGracePeriodSeconds: 150
-          {{- if $storage.securityContext }}          
+          {{- if $storage.securityContext }}
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/helm/fabric/templates/tls_secret.yaml
+++ b/helm/fabric/templates/tls_secret.yaml
@@ -7,7 +7,8 @@
 {{ $annotations := default (list) .Values.annotations }}
 {{ $secrets := default dict .Values.secrets }}
 {{ $secret_annotations := default (list) $secrets.annotations }}
-{{- if and $tlsSecret.enabled (or (and (ne (toString ($tlsSecret.key | default "")) "") (ne (toString ($tlsSecret.crt | default "")) "")) (and (ne (toString ($tlsSecret.key_b64 | default "")) "") (ne (toString ($tlsSecret.crt_b64 | default "")) ""))) }}
+{{ $openshift := .Values.openshift | default false }}
+{{- if and (not $openshift) $tlsSecret.enabled (or (and (ne (toString ($tlsSecret.key | default "")) "") (ne (toString ($tlsSecret.crt | default "")) "")) (and (ne (toString ($tlsSecret.key_b64 | default "")) "") (ne (toString ($tlsSecret.crt_b64 | default "")) ""))) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/fabric/values.test_openshift
+++ b/helm/fabric/values.test_openshift
@@ -1,0 +1,140 @@
+
+openshift: true
+
+namespace:
+  name: "fabric-ocp"
+  create: true
+
+deploy:
+  type: StatefulSet
+
+serviceAccount:
+  create: true
+  name: ""
+  provider: ""
+
+container:
+  replicas: 2
+  annotationsList:
+  - name: description
+    value: Fabric on OpenShift
+  resource_allocation:
+    limits:
+      memory: 8Gi
+      cpu: '2'
+    requests:
+      memory: 2Gi
+      cpu: '0.4'
+  image:
+    url: "docker.share.cloud.k2view.com/fabric:latest"
+    repoSecret:
+      name: "registry-secret"
+      enabled: false
+
+service:
+  listening_port: 3213
+
+storage:
+  pvc:
+    enabled: false
+  securityContext: true
+  class: gp3-csi
+  allocated_amount: 10Gi
+
+scaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 1
+  targetCPU: 90
+
+networkPolicy:
+  egress:
+    enabled: false
+  ingress:
+    enabled: true
+    allowedNamespaces:
+      kubernetes.io/metadata.name: openshift-monitoring
+    allowedPods:
+      app.kubernetes.io/instance: observability
+
+ingress:
+  enabled: true
+  host: fabric.apps.ocp-cluster.example.com
+  path: false
+  subdomain: false
+  tlsSecret:
+    enabled: false
+
+route:
+  enabled: true
+  host: fabric.apps.ocp-cluster.example.com
+  path: ""
+  tls:
+    enabled: true
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+    certificate: ""
+    key: ""
+    caCertificate: ""
+    destinationCACertificate: ""
+  wildcardPolicy: None
+
+mountSecret:
+    name: config-secrets
+    enabled: false
+    mountPath: /opt/apps/fabric/config-secrets
+    data:
+      config: |
+        [fabric]
+        SERVER_AUTHENTICATOR=fabric
+        OVERRIDE_API_SCHEMA=HTTPS
+        OVERRIDE_API_PORT=443
+
+        [fabricdb]
+        MDB_DEFAULT_CACHE_PATH=/opt/apps/fabric/tmp/fdb_cache
+
+        [system_db]
+        SYSTEM_DB_TYPE=POSTGRESQL
+        SYSTEM_DB_HOST=postgres-service
+        SYSTEM_DB_USER=postgres
+        SYSTEM_DB_PASSWORD=postgres
+        SYSTEM_DB_PORT=5432
+        SYSTEM_DB_DATABASE=postgres
+
+        [default_pubsub]
+        TYPE=MEMORY
+
+        [common_area_pubsub]
+        TYPE=MEMORY
+      cp_files: ''
+
+mountSecretB64enc:
+    name: mount-b64-secrets
+    enabled: false
+    mountPath: /opt/apps/fabric/config-secrets
+    data:
+      placeholder: ''
+
+secretsList:
+  - name: common-env-secrets
+    data:
+      PROJECT_ID: ''
+      PROJECT_NAME: ''
+      SPACE_NAME: 'fabric-ocp'
+
+initSecretsList:
+  - name: config-init-secrets
+    data:
+      CONFIG_UPDATE_FILE: '/opt/apps/fabric/config-secrets/config'
+      COPY_FILES: '/opt/apps/fabric/config-secrets/cp_files'
+      GIT_BRANCH: ''
+      GIT_PATH_IN_REPO: ''
+      GIT_REPO: ''
+      GIT_TOKEN: ''
+      START_FABRIC: 'false'
+
+affinity:
+  type: none
+  label:
+    name: topology.kubernetes.io/zone
+    value: region-a

--- a/helm/fabric/values.yaml
+++ b/helm/fabric/values.yaml
@@ -1,3 +1,5 @@
+# Platform toggle: set to true when deploying on OpenShift
+openshift: false
 
 # Global labels for all Fabric resources
 # labels:
@@ -65,6 +67,8 @@ service:
 storage:
   pvc:
     enabled: true  # Create PVC if true, else use ephemeral
+  emptyDir:
+    sizeLimit: 10Gi  # Used for fabric-storage when pvc.enabled is false
   securityContext: true
   class: managed
   allocated_amount: 10Gi
@@ -123,6 +127,21 @@ ingress:
         value: "900"
       - key: nginx.ingress.kubernetes.io/ssl-redirect
         value: "false"
+
+# OpenShift Route Settings (used when openshift: true, replaces Ingress)
+route:
+  enabled: true
+  host: ""  # Leave empty to fall back to ingress.host logic, or set FQDN
+  path: ""
+  tls:
+    enabled: true
+    termination: edge           # edge | passthrough | reencrypt
+    insecureEdgeTerminationPolicy: Redirect  # Allow | Redirect | None
+    certificate: ""
+    key: ""
+    caCertificate: ""
+    destinationCACertificate: ""  # Only for reencrypt
+  wildcardPolicy: None
 
 # Mounting Secrets Settings
 # These settings control how secrets are mounted into the Fabric pods.


### PR DESCRIPTION
# PR: OpenShift Support for Fabric Helm Chart

## Summary

Adds full OpenShift 4.12+ deployment support to the Fabric Helm chart behind a single `openshift: false` toggle. When `false` (default), the chart behaves identically to today. When `true`, it activates Route, anyuid SCC grant, `runAsUser: 1000`, and suppresses resources that OpenShift replaces or manages itself.

---

## Changes

### 1. Platform Toggle (`values.yaml`)

Added top-level `openshift: false`. All OpenShift-specific behaviour is gated on this single value — operators do not need to understand the internals, only set this flag.

Also added `storage.emptyDir.sizeLimit` (default `10Gi`) to control the size of the ephemeral workspace volume when `pvc.enabled: false`.

```yaml
# Platform toggle: set to true when deploying on OpenShift
openshift: false

storage:
  pvc:
    enabled: true
  emptyDir:
    sizeLimit: 10Gi   # used for fabric-storage when pvc.enabled is false
```

---

### 2. OpenShift Route (`templates/route.yaml`) — new file

New template that renders an `route.openshift.io/v1` Route when `openshift: true`. Suppressed entirely on standard Kubernetes.

- Host and path resolved with the same fallback logic as `ingress.yaml` (uses `ingress.host`/`ingress.subdomain`/`ingress.path` if `route.host`/`route.path` are empty), so operators do not need to duplicate hostname config.
- TLS defaults to `edge` termination with HTTP→HTTPS redirect. Custom certificates supported via `route.tls.certificate`/`key`. Leave empty to use the cluster's default wildcard certificate.

Values stanza added to `values.yaml`:
```yaml
route:
  enabled: true
  host: ""
  path: ""
  tls:
    enabled: true
    termination: edge
    insecureEdgeTerminationPolicy: Redirect
    certificate: ""
    key: ""
    caCertificate: ""
    destinationCACertificate: ""  # reencrypt only
  wildcardPolicy: None
```

---

### 3. Ingress Suppressed on OpenShift (`templates/ingress.yaml`)

Added `$openshift` variable. The `Ingress` resource is now skipped when `openshift: true` — the Route (above) takes its place.

```diff
-{{ if $ingress.enabled | default true }}
+{{ if and (not $openshift) ($ingress.enabled | default true) }}
```

---

### 4. TLS Secret Suppressed on OpenShift (`templates/tls_secret.yaml`)

The `tls_secret` resource is suppressed when `openshift: true`. On OpenShift, TLS is terminated at the Route; a separate TLS Secret in the namespace is unused and creates noise.

```diff
-{{- if and $tlsSecret.enabled (or ...) }}
+{{- if and (not $openshift) $tlsSecret.enabled (or ...) }}
```

---

### 5. anyuid SCC Grant + `runAsUser: 1000` (`templates/scc_rolebinding.yaml`, `templates/deployment.yaml`, `templates/statefulsets.yaml`) — new file

#### Root cause

The Fabric image has files (e.g. `/opt/apps/fabric/fabric/.code-guard.key`) owned by uid `1000` with restrictive permissions. Under `restricted-v2` SCC, OpenShift assigns a random UID from the namespace's range (e.g. `1000650000`), which cannot read those files. This causes an `AccessDeniedException` at JVM boot and a crash loop.

#### Fix — Part 1: Automated SCC RoleBinding (`templates/scc_rolebinding.yaml`)

New template that renders only when `openshift: true`. Binds the `system:openshift:scc:anyuid` ClusterRole to the Fabric ServiceAccount, granting it permission to run as any UID including `1000`.

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: fabric-anyuid-scc
  namespace: <namespace>
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system:openshift:scc:anyuid
subjects:
  - kind: ServiceAccount
    name: <service-account>
    namespace: <namespace>
```

**Note:** The deploying user must have permission to create RoleBindings for the anyuid ClusterRole (typically cluster-admin or a delegated role).

#### Fix — Part 2: Pod-level `runAsUser: 1000`

Granting anyuid only *allows* running as uid `1000` — the pod must *request* it explicitly. The pod-level securityContext guard was changed to apply on OpenShift as well as standard Kubernetes:

```diff
-{{- if and $storage.securityContext (not $openshift) }}
+{{- if $storage.securityContext }}
 securityContext:
   runAsUser: 1000
   runAsGroup: 1000
   fsGroup: 1000
```

#### Fix — Part 3: Removed container-level seccomp/capabilities blocks

After enabling `runAsUser: 1000` with anyuid, the container-level `seccompProfile` fields caused admission to fail:

```
pods is forbidden: unable to validate against any security context constraint:
  pod.metadata.annotations[container.seccomp.security.alpha.kubernetes.io/init-fabric]:
    Forbidden: seccomp may not be set
```

The anyuid SCC does not permit container-level seccomp annotations. The OCP-specific container securityContext blocks (capabilities drop, runAsNonRoot, seccompProfile) were removed from both init and main containers in both Deployment and StatefulSet. `allowPrivilegeEscalation: false` is retained as it is universally valid:

```diff
-{{- if $openshift }}
-securityContext:
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop: ["ALL"]
-  runAsNonRoot: true
-  seccompProfile:
-    type: RuntimeDefault
-{{- end }}
+# removed — anyuid SCC + runAsUser: 1000 makes these redundant and conflicting
```

---

### 6. Added HOME Environment Variable (`templates/deployment.yaml`, `templates/statefulsets.yaml`)

**Added to both init container and main container env sections:**

```yaml
- name: HOME
  value: /opt/apps/fabric
```

**Why:** On OpenShift, containers run as a UID that has no `/etc/passwd` entry. The `bash -l` (login shell) invocation in the container cannot resolve `HOME` for unknown UIDs and resets it to `/`. This breaks every `${HOME}/...` path used in the entrypoint script. Setting `HOME` explicitly in the pod spec ensures it is correct regardless of the assigned UID.

**Note:** With the `anyuid` SCC and `runAsUser: 1000`, this is technically redundant since uid 1000 exists in `/etc/passwd`. It remains as an explicit safety net for clusters using `restricted-v2` or any SCC that does not pin a UID.

---

### 7. NetworkPolicy: Allow OpenShift Ingress Traffic (`templates/ingress_np.yaml`)

When `networkPolicy.ingress.enabled: true` and `openshift: true`, an additional ingress rule is appended to allow traffic from the `openshift-ingress` namespace (the HAProxy router pods). Without this, the NetworkPolicy blocks the Route's backend traffic.

```yaml
- ports:
    - protocol: TCP
      port: 3213
  from:
    - namespaceSelector:
        matchLabels:
          network.openshift.io/policy-group: ingress
```

---

### 8. Configurable `fabric-storage` Volume (`templates/deployment.yaml`)

The `fabric-storage` volume (workspace) now respects `pvc.enabled` in the Deployment, matching the existing StatefulSet behaviour:

- `pvc.enabled: true` (default) → `PersistentVolumeClaim` (`fabric-claim`)
- `pvc.enabled: false` → `emptyDir` with `sizeLimit` from `storage.emptyDir.sizeLimit`

This allows ephemeral Deployment mode (e.g. dev/OCP clusters without a storage class) without having to also disable the PVC template.

---

### 9. Fix: `pvc.enabled: false` Was Silently Ignored (`templates/pvc.yaml`, `templates/deployment.yaml`, `templates/statefulsets.yaml`)

**Bug:** `{{ if $pvc.enabled | default true }}` — Helm's `default` function treats boolean `false` as falsy (empty) and substitutes the default value `true`. Setting `pvc.enabled: false` therefore had no effect; a PVC was always created.

**Fix:** Replace with `{{ if ne (toString $pvc.enabled) "false" }}` across all three templates. This correctly distinguishes between "not set" (→ create PVC) and "explicitly false" (→ skip PVC / use emptyDir).

---

### 10. README Updates (`README.md`)

- Prerequisites updated: `Kubernetes 1.30+ or OpenShift 4.12+`; note that Ingress controller is not required on OpenShift
- Parameters table: `openshift`, all `route.*` keys, corrected `mountSecretB64enc.mountPath` default value
- New **OpenShift Support** section with behaviour comparison table, minimal values example, and Route host/path resolution documentation

---

## Behaviour Matrix

| `openshift` | `pvc.enabled` | Storage | Ingress | Route | TLS Secret | SCC RoleBinding | Pod runAsUser |
|-------------|---------------|---------|---------|-------|------------|-----------------|---------------|
| `false` | `true` | PVC | Created | — | Created | — | 1000 |
| `false` | `false` | emptyDir | Created | — | Created | — | 1000 |
| `true` | `true` | PVC | Suppressed | Created | Suppressed | anyuid | 1000 |
| `true` | `false` | emptyDir | Suppressed | Created | Suppressed | anyuid | 1000 |

---

## Testing

Verified with `helm install --dry-run` and live install against OpenShift 4.x (`restricted-v2` SCC):

```bash
helm install space-tenant ./helm/fabric \
  --namespace space-tenant \
  --set openshift=true \
  --set storage.pvc.enabled=false \
  --set storage.emptyDir.sizeLimit=5Gi \
  --set container.image.url=<image> \
  --set route.host=space-tenant.apps.cluster.example.com
```

Standard Kubernetes installs (no `openshift` flag) are unaffected — all new code paths are behind the `openshift: false` default.
